### PR TITLE
Load module loader on after_setup_theme instead of init

### DIFF
--- a/module-loader.php
+++ b/module-loader.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'init', 'eig_load_modules' );
+add_action( 'after_setup_theme', 'eig_load_modules' );
 
 /**
  * Initialize the module loader.

--- a/module-loader.php
+++ b/module-loader.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'after_setup_theme', 'eig_load_modules' );
+add_action( 'after_setup_theme', 'eig_load_modules', 100 );
 
 /**
  * Initialize the module loader.


### PR DESCRIPTION
Fixes #1 

I tried using `plugins_loaded` and my widget still wasn't initializing. Haven't dug into why yet, but I suspect the module wasn't loading completely. Anyway, I think using `after_setup_theme` should be fine for our needs. 